### PR TITLE
Drop the redundant axes(::SparsityPatternCSC, ::Integer) method (invalidates 2k+ ModelingToolkit instances on load)

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -26,7 +26,6 @@ SparsityPatternCSC(A::SparseMatrixCSC) = SparsityPatternCSC(A.m, A.n, A.colptr, 
 SparseArrays.indtype(::SparsityPatternCSC{T}) where {T} = T
 Base.size(S::SparsityPatternCSC) = (S.m, S.n)
 Base.size(S::SparsityPatternCSC, d::Integer) = d::Integer <= 2 ? size(S)[d] : 1
-Base.axes(S::SparsityPatternCSC, d::Integer) = Base.OneTo(size(S, d))
 
 SparseArrays.nnz(S::SparsityPatternCSC) = length(S.rowval)
 SparseArrays.rowvals(S::SparsityPatternCSC) = S.rowval

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -69,8 +69,10 @@ using Test
         @test size(A, 1) == size(S, 1)
         @test size(A, 2) == size(S, 2)
         @test size(A, 3) == size(S, 3)
+        @test axes(A) == axes(S)
         @test axes(A, 1) == axes(S, 1)
         @test axes(A, 2) == axes(S, 2)
+        @test axes(A, 3) == axes(S, 3)
     end
     @testset "getindex" begin
         A = sprand(Bool, 100, 100, 0.1)


### PR DESCRIPTION
## What

Removes `Base.axes(S::SparsityPatternCSC, d::Integer) = Base.OneTo(size(S, d))` from `src/graph.jl`. `SparsityPatternCSC <: AbstractMatrix{Bool}` and defines `size`, so Base's fallback `axes(A::AbstractArray, d)` already returns exactly `OneTo(size(S, d))` (and `OneTo(1)` for `d > 2`, same as before). Adds `axes(A) == axes(S)` and the `d = 3` case to the existing `size` testset so the behaviour stays pinned.

## Why

Adding that method at load time invalidates every `axes(A, d)` call site that was compiled earlier with an abstract `A` (`axes(::AbstractArray, ::Int64)`, `axes(::AbstractMatrix, ::Int64)`, `axes(::AbstractArray, ::Any)` all take a backedge to the method table). SparseMatrixColorings is loaded by OrdinaryDiffEqDifferentiation, i.e. after ModelingToolkit, and on that stack the insertion kills 3,055 cached instances, 2,049 of them in ModelingToolkit / ModelingToolkitBase / ModelingToolkitTearing / Symbolics: `__mtkcompile`, `_mtkcompile`, `maybe_build_initialization_problem`, `process_SciMLProblem`, `alias_elimination!`, `find_eq_solvables!`, `ODEProblem`, `NonlinearProblem`. In practice `using ModelingToolkit, OrdinaryDiffEq` discards the model-building code that ModelingToolkit's precompile workload just cached.

Measured with `SnoopCompileCore.@snoop_invalidations using OrdinaryDiffEq` after `using ModelingToolkit` (Julia 1.12.7, ModelingToolkit 11.40, OrdinaryDiffEq 7.8.1, SparseMatrixColorings 0.4.27 vs this branch `Pkg.develop`ed):

| | instances invalidated by the `axes` insertion | of which ModelingToolkit-family | build the workload models after `using OrdinaryDiffEq` |
|---|---|---|---|
| 0.4.27 | 3,055 | 2,049 | 12.3 s / 3.4 s |
| this branch | – (method gone) | **0** | **0.37 s / 0.10 s** |

(The last column is `mtkcompile` + `ODEProblem` for a small ODE and a small DAE that ModelingToolkit's own workload compiles; with the invalidation those take 12.3 s and 3.4 s on first use even though they are in the pkgimage.)

## Tests

`Pkg.test()` on Julia 1.12.7: `SparseMatrixColorings | 50464 pass, 31 broken (pre-existing) | 11m44s`, tests passed. `JuliaFormatter` (`BlueStyle`) reports both touched files formatted.

Context (analysis and scripts): https://github.com/ChrisRackauckas/InternalJunk/issues/88#issuecomment-5537967759. SciML also carries a defensive canary for this pattern in https://github.com/SciML/CommonWorldInvalidations.jl/pull/45; this PR is the fix at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1) on behalf of Chris Rackauckas
https://claude.ai/code/session_01FeJYXni9MkJhPFA9yxYvfn
